### PR TITLE
fix #15: Added support for manual location

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ cloud_speed         |0.1          | Cloud speed in pixels/update when using anim
 minimum_percent_of_last_cloud|5   | Minumum percent shown of the last cloud created before creating a new cloud when using animated background
 raindrop_speed      | 3           | Raindrop falling speed in pixels/update when using animated background. Adjust the value according to your system.
 snowflake_speed     | 1           | Snowflake falling speed in pixels/update when using animated background. Adjust the value according to your system.
+latitude            |             | If provided, will force the latitude for clock's location
+longitude           |             | If provided, will force the longitude for clock's location
 
 ## Requirements
 

--- a/config/pygame_clock.json
+++ b/config/pygame_clock.json
@@ -19,6 +19,6 @@
   "night_color": [12,20,69],
   "cloud_speed": 0.1,
   "minimum_percent_of_last_cloud": 5,
-  "raindrop_speed": 3,
+  "raindrop_speed": 15,
   "snowflake_speed": 1
 }

--- a/mylocation.py
+++ b/mylocation.py
@@ -3,23 +3,42 @@
 import re
 import json
 import urllib3
+from geopy.geocoders import Nominatim
+
 
 class MyLocation:
     """A class to know the location where I am running"""
 
-    def __init__(self):
+    def __init__(self, pclock):
         """Creates the object with the location"""
+        self.settings = pclock.settings
+        if (hasattr(self.settings,'latitude') and
+            hasattr(self.settings,'longitude')):
+            self.load_from_nominatim()
+        else:
+            self.load_from_ipinfo()
+
+    def load_from_ipinfo(self):
+        """Sets the location from ipinfo"""
         connection = urllib3.connection_from_url('http://ipinfo.io/')
         response = connection.request('GET','/json')
         data = json.loads(response.data.decode('utf-8'))
-        self.ip = data['ip']
         self.city = data['city']
         self.region = data['region']
         self.country = data['country']
         latitude,longitude = data['loc'].split(",")
         self.lat = float(latitude)
         self.long = float(longitude)
-        self.org = data['org']
         self.postal = data['postal']
-        self.timezone = data['timezone']
-        self.readme = data['readme']
+
+    def load_from_nominatim(self):
+        """Sets the location data from Nominatim"""
+        geolocator = Nominatim(user_agent="pygame_clock")
+        coordinates = f"{self.settings.latitude}, {self.settings.longitude}"
+        location = geolocator.reverse(coordinates)
+        self.city = location.raw['address']['city']
+        self.region = location.raw['address']['state']
+        self.country = location.raw['address']['country']
+        self.lat = float(self.settings.latitude)
+        self.long = float(self.settings.longitude)
+        self.postal = location.raw['address']['postcode']

--- a/pygame_clock.py
+++ b/pygame_clock.py
@@ -22,7 +22,7 @@ class PyGameClock:
         pygame.init()
 
         self.settings = Settings()
-        self.location = MyLocation()
+        self.location = MyLocation(self)
         self.latitude = self.location.lat
         self.longitude = self.location.long
         self.weather = WeatherAtLocation(self)

--- a/settings.py
+++ b/settings.py
@@ -61,6 +61,10 @@ class Settings:
             self.raindrop_speed = all_settings["raindrop_speed"]
         if('snowflake_speed' in all_settings):
             self.snowflake_speed = all_settings["snowflake_speed"]
+        if('latitude' in all_settings):
+            self.latitude = all_settings["latitude"]
+        if('longitude' in all_settings):
+            self.longitude = all_settings["longitude"]
 
         # Make sure we are not exceeding 100 percent of screen with the
         # size of the data shown on screen and if so, 
@@ -85,7 +89,7 @@ class Settings:
         self.minimum_percent_of_last_cloud = 10
 
         # Rain settings
-        self.raindrop_speed = 3
+        self.raindrop_speed = 15
 
         # Snowflake settings
         self.snowflake_speed = 3


### PR DESCRIPTION
This will add support to provide the latitude and longitude for the desired location of the clock. If it is empty, it will continue using ipinfo.io to calculate location